### PR TITLE
Add main field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "homepage": "http://brm.io/matter-js/",
   "author": "Liam Brummitt <liam@brm.io> (http://brm.io/)",
   "description": "a 2D rigid body physics engine for the web",
+  "main": "build/matter.js",
   "repository":{ 
     "type" : "git", 
     "url" : "https://github.com/liabru/matter-js.git"


### PR DESCRIPTION
This makes requiring the Matter module using `require('Matter')` possible.

Needed for use with node.js/browserify.
