### PR TITLE
IE 6-8 Compatibility

### DIFF
--- a/src/body/Composite.js
+++ b/src/body/Composite.js
@@ -148,7 +148,7 @@ var Composite = {};
      * @return {composite} The original compositeA with the composite removed
      */
     Composite.removeComposite = function(compositeA, compositeB, deep) {
-        var position = compositeA.composites.indexOf(compositeB);
+        var position = Common.indexOf(compositeA.composites, compositeB);
         if (position !== -1) {
             Composite.removeCompositeAt(compositeA, position);
             Composite.setModified(compositeA, true, true, false);
@@ -198,7 +198,7 @@ var Composite = {};
      * @return {composite} The original composite with the body removed
      */
     Composite.removeBody = function(composite, body, deep) {
-        var position = composite.bodies.indexOf(body);
+        var position = Common.indexOf(composite.bodies, body);
         if (position !== -1) {
             Composite.removeBodyAt(composite, position);
             Composite.setModified(composite, true, true, false);
@@ -248,7 +248,7 @@ var Composite = {};
      * @return {composite} The original composite with the constraint removed
      */
     Composite.removeConstraint = function(composite, constraint, deep) {
-        var position = composite.constraints.indexOf(constraint);
+        var position = Common.indexOf(composite.constraints, constraint);
         if (position !== -1) {
             Composite.removeConstraintAt(composite, position);
         }

--- a/src/collision/Grid.js
+++ b/src/collision/Grid.js
@@ -244,7 +244,7 @@ var Grid = {};
      */
     var _bucketRemoveBody = function(grid, bucket, body) {
         // remove from bucket
-        bucket.splice(bucket.indexOf(body), 1);
+        bucket.splice(Common.indexOf(bucket, body), 1);
 
         // update pair counts
         for (var i = 0; i < bucket.length; i++) {

--- a/src/collision/Pairs.js
+++ b/src/collision/Pairs.js
@@ -85,7 +85,7 @@ var Pairs = {};
         // deactivate previously active pairs that are now inactive
         for (i = 0; i < pairsList.length; i++) {
             pair = pairsList[i];
-            if (pair.isActive && activePairIds.indexOf(pair.id) === -1) {
+            if (pair.isActive && Common.indexOf(activePairIds, pair.id) === -1) {
                 Pair.setActive(pair, false, timestamp);
                 collisionEnd.push(pair);
             }

--- a/src/core/Common.js
+++ b/src/core/Common.js
@@ -278,4 +278,24 @@ var Common = {};
         return Common._nextId++;
     };
 
+    /**
+     * A wrapper for console.log, for providing errors and warnings
+     * @method indexOf
+     * @param {array} haystack
+     * @param {object} needle
+     */
+    Common.indexOf = function(haystack, needle) {
+        if(haystack.indexOf) {
+            return haystack.indexOf(needle);
+        } else {
+            for(var i = 0; i < haystack.length; i++) {
+                if(haystack[i] == needle) {
+                    return i;
+                }
+            }
+        }
+        return -1;
+    };
+
+
 })();

--- a/src/render/RenderPixi.js
+++ b/src/render/RenderPixi.js
@@ -203,7 +203,7 @@ var RenderPixi = {};
         }
 
         // add to scene graph if not already there
-        if (stage.children.indexOf(primitive) === -1)
+        if (Common.indexOf(stage.children, primitive) === -1)
             stage.addChild(primitive);
 
         // render the constraint on every update, since they can change dynamically
@@ -249,7 +249,7 @@ var RenderPixi = {};
                 sprite = render.sprites[spriteId] = _createBodySprite(render, body);
 
             // add to scene graph if not already there
-            if (spriteBatch.children.indexOf(sprite) === -1)
+            if (Common.indexOf(spriteBatch.children, sprite) === -1)
                 spriteBatch.addChild(sprite);
 
             // update body sprite
@@ -268,7 +268,7 @@ var RenderPixi = {};
             }
 
             // add to scene graph if not already there
-            if (stage.children.indexOf(primitive) === -1)
+            if (Common.indexOf(stage.children, primitive) === -1)
                 stage.addChild(primitive);
 
             // update body primitive


### PR DESCRIPTION
IE 6-8 has no indexOf method on Arrays.  Instead this introduces the method on Common and will use a native implementation if it exists and a javascript one if not.

(note: running matter-js on older versions of IE will still require a custom renderer, as canvas/webgl is not supported)
