### PR TITLE
Makes the demo actually work

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,8 @@ module.exports = function(grunt) {
         options: {
           port: 9000,
           open: 'http://localhost:9000/demo/dev.html',
-          livereload: 9001
+          livereload: 9001,
+          keepalive: true
         }
       }
     },

--- a/demo/dev.html
+++ b/demo/dev.html
@@ -10,7 +10,7 @@
         <script type="text/javascript" src="./js/lib/pixi.dev.js"></script>
 
         <!-- matter lib edge master version -->
-        <script type="text/javascript" src="./js/lib/matter-dev.js"></script>
+        <script type="text/javascript" src="./js/lib/matter-0.8.0.js"></script>
 
         <!-- only required if using MatterTools -->
         <link rel="stylesheet" href="./js/lib/matter-tools/matter-tools.css" type="text/css">


### PR DESCRIPTION
by adding the keepalive : true option to the Gruntfile and
by adding a reference to the matter.js file that actually exists in lib (it was calling an edge version that isn't included in demo/js/lib/  -- the matter.js file that was in the lib folder was matter-0.8.0.js). Now the demo works.
