### PR TITLE
Make background:'transparent' work like canvas renderer

### DIFF
--- a/src/render/RenderPixi.js
+++ b/src/render/RenderPixi.js
@@ -41,10 +41,11 @@ var RenderPixi = {};
             }
         };
 
-        var render = Common.extend(defaults, options);
+        var render = Common.extend(defaults, options),
+            transparent = !render.options.wireframes && render.options.background === 'transparent';
 
         // init pixi
-        render.context = new PIXI.WebGLRenderer(render.options.width, render.options.height, render.canvas, false, true);
+        render.context = new PIXI.WebGLRenderer(render.options.width, render.options.height, render.canvas, transparent, true);
         render.canvas = render.context.view;
         render.stage = new PIXI.Stage();
 


### PR DESCRIPTION
There's currently no way to make the renderpixi use a transparent background. In the canvas renderer it works by setting a css property ("background:transparent") but the webgl context needs to be passed to the Pixi constructor. I made the two versions work the same way (set "background:transparent" in options) as I need my project to work the same with both Matter.Render and Matter.RenderPixi.

In Matter.Render you can set any CSS property (including an image). This doesn't fix that, but you can set a colour or transparent and set the image in CSS
