### PR TITLE
Body.setStatic no longer sets render.lineWidth to 1

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -126,7 +126,6 @@ var Body = {};
             body.friction = 1;
             body.mass = body.inertia = body.density = Infinity;
             body.inverseMass = body.inverseInertia = 0;
-            body.render.lineWidth = 1;
 
             body.positionPrev.x = body.position.x;
             body.positionPrev.y = body.position.y;


### PR DESCRIPTION
Body.setStatic no longer sets render.lineWidth to 1, so it takes the default width or the one in the config.
