### PR TITLE
When updating pairs use current values from bodies as they may have changed

### DIFF
--- a/src/collision/Pair.js
+++ b/src/collision/Pair.js
@@ -51,6 +51,10 @@ var Pair = {};
             activeContacts = pair.activeContacts;
         
         pair.collision = collision;
+        pair.inverseMass = collision.bodyA.inverseMass + collision.bodyB.inverseMass;
+        pair.friction = Math.min(collision.bodyA.friction, collision.bodyB.friction);
+        pair.restitution = Math.max(collision.bodyA.restitution, collision.bodyB.restitution);
+        pair.slop = Math.max(collision.bodyA.slop, collision.bodyB.slop);
         activeContacts.length = 0;
         
         if (collision.collided) {


### PR DESCRIPTION
In a dynamic system, a user might be changing properties of a body.  Collision pairs need to use the updated values otherwise the collision will not be as expected.
