### PR TITLE
don't calculate gravity force if there is no actual gravity

### DIFF
--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -286,6 +286,9 @@ var Engine = {};
      * @param {vector} gravity
      */
     var _bodiesApplyGravity = function(bodies, gravity) {
+        if (gravity.x === 0 && gravity.y === 0) {
+            return;
+        }
         for (var i = 0; i < bodies.length; i++) {
             var body = bodies[i];
 


### PR DESCRIPTION
Very small tweak to avoid unnecessary calculations of force when there is no gravity to apply.