### PR TITLE
Fixed unnecessary poly-decomp.js required warning

### DIFF
--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -199,10 +199,6 @@ var Bodies = {};
         removeCollinear = typeof removeCollinear !== 'undefined' ? removeCollinear : 0.01;
         minimumArea = typeof minimumArea !== 'undefined' ? minimumArea : 10;
 
-        if (!window.decomp) {
-            Common.log('Bodies.fromVertices: poly-decomp.js required. Could not decompose vertices. Fallback to convex hull.', 'warn');
-        }
-
         // ensure vertexSets is an array of arrays
         if (!Common.isArray(vertexSets[0])) {
             vertexSets = [vertexSets];
@@ -217,6 +213,7 @@ var Bodies = {};
                     vertices = Vertices.clockwiseSort(vertices);
                 } else {
                     // fallback to convex hull when decomposition is not possible
+                    Common.log('Bodies.fromVertices: poly-decomp.js required. Could not decompose vertices. Fallback to convex hull.', 'warn');
                     vertices = Vertices.hull(vertices);
                 }
 


### PR DESCRIPTION
This fixes the missing "poly-decomp.js" warning being issued even when not necessary (the vertices form a convex hull).