### PR TITLE
Ensure passed canvas abides by render options

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -64,6 +64,10 @@ var Grid = require('../collision/Grid');
 
         var render = Common.extend(defaults, options);
 
+        if(render.canvas) {
+            render.canvas.width = render.options.width || render.canvas.width;
+            render.canvas.height = render.options.height || render.canvas.height;
+        }
         render.canvas = render.canvas || _createCanvas(render.options.width, render.options.height);
         render.context = render.canvas.getContext('2d');
         render.textures = {};


### PR DESCRIPTION
Engine.create takes a canvas element or creates a new canvas using the given options. While the properties width and height in options do apply to the created canvas, they do not apply to the passed canvas. These set options are under render.canvas, render.options.width and render.options.height. This issue was fixed by setting the canvas width and height only when a canvas element is directly provided. The added code also includes a fallback to the original width and height if options width and/or height were not passed.