### PR TITLE
fps counter only in debug

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -266,9 +266,9 @@ var Vector = require('../geometry/Vector');
 
         if (engine.timing.timestamp - (render.debugTimestamp || 0) >= 500) {
             var text = "";
-            text += "fps: " + Math.round(metrics.timing.fps) + space;
 
             // @if DEBUG
+            text += "fps: " + Math.round(metrics.timing.fps) + space;
             if (metrics.extended) {
                 text += "delta: " + metrics.timing.delta.toFixed(3) + space;
                 text += "correction: " + metrics.timing.correction.toFixed(3) + space;


### PR DESCRIPTION
fps is a property of the runner, not the engine, therefore the engine
shouldn't know about it.