### PR TITLE
Adding the opacity attribute to be able to draw semi-transarent sprites

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -71,6 +71,7 @@ var Axes = require('../geometry/Axes');
             timeScale: 1,
             render: {
                 visible: true,
+                opacity: 1,
                 sprite: {
                     xScale: 1,
                     yScale: 1,

--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -445,6 +445,10 @@ var Vector = require('../geometry/Vector');
                     if (options.showSleeping && body.isSleeping) 
                         c.globalAlpha = 0.5;
 
+                    if (part.render.opacity !== 1)
+                        c.globalAlpha = part.render.opacity;
+
+
                     c.translate(part.position.x, part.position.y); 
                     c.rotate(part.angle);
 
@@ -460,7 +464,7 @@ var Vector = require('../geometry/Vector');
                     c.rotate(-part.angle);
                     c.translate(-part.position.x, -part.position.y); 
 
-                    if (options.showSleeping && body.isSleeping) 
+                    if ((options.showSleeping && body.isSleeping) || part.render.opacity !== 1) 
                         c.globalAlpha = 1;
                 } else {
                     // part polygon


### PR DESCRIPTION
Just a really simple suggestion, adding a tiny feature I think could be useful.
Sprites are drawn with the desired opacity just by tuning the globalAlpha attribute
already used to make things semi-transparent when sleeping.