### PR TITLE
Fix the out-of-bounds check in grid broadphase

### DIFF
--- a/src/collision/Grid.js
+++ b/src/collision/Grid.js
@@ -62,8 +62,8 @@ var Common = require('../core/Common');
                 continue;
 
             // don't update out of world bodies
-            if (body.bounds.max.x < 0 || body.bounds.min.x > world.bounds.width
-                || body.bounds.max.y < 0 || body.bounds.min.y > world.bounds.height)
+            if (body.bounds.max.x < world.bounds.min.x || body.bounds.min.x > world.bounds.max.x
+                || body.bounds.max.y < world.bounds.min.y || body.bounds.min.y > world.bounds.max.y)
                 continue;
 
             var newRegion = _getRegion(grid, body);


### PR DESCRIPTION
Was wondering why some of my objects weren't colliding properly. Took a while to figure out there is such a thing as `world.bounds`. It is mentioned in the description of the `World` object, but not listed in the properties at the bottom of the [documentation](http://brm.io/matter-js/docs/classes/World.html).

Also the checks involving this in the broadphase are faulty, so despite the bounds being set to `-Infinity...Infinity`, the Grid ignores this and (due to comparison to undefined) ends up effectively using bounds from `0...Infinity` no matter what the actual bounds are set to.

---------------------

`gulp lint` goes through okay, but `gulp test:browser` errors out. This happens on the `master` branch as well. Running phantomjs on its own gives the following error:

```
wace@jubjub:~/projects/matter-js$ phantomjs test/browser/TestDemo.js
testing 'undefined'
TypeError: 'undefined' is not a function (evaluating 'this._loadResource.bind(this)')
 at http://localhost:8000/demo/js/lib/pixi.js: 4995 (fn: Loader)
 at http://localhost:8000/demo/js/lib/pixi.js: 26131 (fn: Loader)
 at http://localhost:8000/demo/js/lib/pixi.js: 23
 at http://localhost:8000/demo/js/lib/pixi.js: 31
 at http://localhost:8000/demo/js/lib/pixi.js: 1 (fn: s)
 at http://localhost:8000/demo/js/lib/pixi.js: 1 (fn: e)
 at http://localhost:8000/demo/js/lib/pixi.js: 27289
 at http://localhost:8000/demo/js/lib/pixi.js: 1
 at http://localhost:8000/demo/js/lib/pixi.js: 27290
```