### PR TITLE
RenderPixi.js - Add missing dependencies

### DIFF
--- a/src/render/RenderPixi.js
+++ b/src/render/RenderPixi.js
@@ -9,8 +9,10 @@ var RenderPixi = {};
 
 module.exports = RenderPixi;
 
+var Bounds = require('../geometry/Bounds');
 var Composite = require('../body/Composite');
 var Common = require('../core/Common');
+var Vector = require('../geometry/Vector');
 
 (function() {
     


### PR DESCRIPTION
When bounds are passed to the Pixi render, the Bounds and Vector objects are used but are not imported