### PR TITLE
Limit packaging extraneous files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,9 +1,0 @@
-.idea
-node_modules
-npm-debug.log
-doc
-matter-doc-theme
-build/matter-dev.js
-build/matter-dev.min.js
-demo/js/lib/matter-dev.js
-test/browser/diffs

--- a/package.json
+++ b/package.json
@@ -52,5 +52,10 @@
   "scripts": {
     "test": "gulp build:dev && gulp build:examples && gulp lint"
   },
-  "dependencies": {}
+  "dependencies": {},
+  "files": [
+    "src",
+    "build",
+    "CHANGELOG.md"
+  ]
 }


### PR DESCRIPTION
matter.js is including a lot of extra files when published to npm. This PR removes them.

Here are the list of files that are currently being published:
```
   36.2 MiB [ 90.7%] /test                                                                                                                                                      
    2.7 MiB [  6.8%] /demo
  376.0 KiB [  0.9%] /build
  352.0 KiB [  0.9%] /src
  176.0 KiB [  0.4%] /examples
   44.0 KiB [  0.1%]  CHANGELOG.md
   12.0 KiB [  0.0%]  README.md
   12.0 KiB [  0.0%]  Gulpfile.js
    4.0 KiB [  0.0%]  package.json
    4.0 KiB [  0.0%]  .eslintrc
    4.0 KiB [  0.0%]  LICENSE
    4.0 KiB [  0.0%]  CONTRIBUTING.md
    4.0 KiB [  0.0%]  bower.json
    4.0 KiB [  0.0%]  .travis.yml
    4.0 KiB [  0.0%]  .npmignore
```

This PR removes things like `CONTRIBUTING.md` and `.travis.yml`.
`package.json`, the `README`, and the `LICENSE` are automatically retained by NPM.

https://docs.npmjs.com/files/package.json#files