### PR TITLE
Render: canvas element supports transparent backgrounds now.

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -1207,12 +1207,16 @@ var Vector = require('../geometry/Vector');
      */
     var _applyBackground = function(render, background) {
         var cssBackground = background;
+        var backgroundSize = "contain";
 
-        if (/(jpg|gif|png)$/.test(background))
+        if (background === "transparent") {
+            render.canvas.style = "background";
+        } else if (/(jpg|gif|png)$/.test(background)) {
             cssBackground = 'url(' + background + ')';
+            render.canvas.style.background = cssBackground;
+            render.canvas.style.backgroundSize = "contain";
+        }
 
-        render.canvas.style.background = cssBackground;
-        render.canvas.style.backgroundSize = "contain";
         render.currentBackground = background;
     };
 


### PR DESCRIPTION
There's a [similar PR](https://github.com/liabru/matter-js/pull/33) (merged) adding a `background: transparent` override to the canvas rendering element. 

Personally, I'd suggest dropping CSS background rule validation in `_applyBackground` completely, or enabling a 'transparent' setting as in the PR attached. What do You think?

My use case was compositing multiple canvas elements (say, in a game scenario, where background is animated). Using transparent canvas elements pushes some of the compositing logic to GPU which might be a performance improvements in some situations.
