### PR TITLE
Fixed Common.isString on IE

### DIFF
--- a/src/core/Common.js
+++ b/src/core/Common.js
@@ -245,7 +245,7 @@ module.exports = Common;
      * @return {boolean} True if the object is a string, otherwise false
      */
     Common.isString = function(obj) {
-        return toString.call(obj) === '[object String]';
+        return Object.prototype.toString.call(obj) === '[object String]';
     };
     
     /**


### PR DESCRIPTION
IE throws an error when you call `window.toString()` on an object: `TypeError: Invalid calling object`. This PR switches to using `Object.prototype.toString` instead.

http://stackoverflow.com/questions/27053688/ie-11-not-liking-tostring-callvalue