### PR TITLE
Fix for bug #378: Update inertia when updating mass

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -148,9 +148,10 @@ var Axes = require('../geometry/Axes');
         Body.set(body, {
             axes: options.axes || body.axes,
             area: options.area || body.area,
-            mass: options.mass || body.mass,
-            inertia: options.inertia || body.inertia
+            mass: options.mass || body.mass
         });
+        // Custom inertia must be set after mass because mass affects inertia.
+        Body.setInertia(body, options.inertia || body.inertia);
 
         // render properties
         var defaultFillStyle = (body.isStatic ? '#2e2b44' : Common.choose(['#006BA6', '#0496FF', '#FFBC42', '#D81159', '#8F2D56'])),
@@ -281,6 +282,11 @@ var Axes = require('../geometry/Axes');
      * @param {number} mass
      */
     Body.setMass = function(body, mass) {
+        // body.inertia is undefined when creating the body
+        // body.inertia is Infinity when body is static or sleeping
+        if (body.inertia !== undefined && body.inertia !== Infinity)
+            Body.setInertia(body, body.inertia * mass / body.mass);
+        
         body.mass = mass;
         body.inverseMass = 1 / body.mass;
         body.density = body.mass / body.area;

--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -179,10 +179,10 @@ var Axes = require('../geometry/Axes');
         }
 
         for (property in settings) {
-            value = settings[property];
-
             if (!settings.hasOwnProperty(property))
                 continue;
+            
+            value = settings[property];
 
             switch (property) {
 

--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -276,7 +276,7 @@ var Axes = require('../geometry/Axes');
     };
 
     /**
-     * Sets the mass of the body. Inverse mass and density are automatically updated to reflect the change.
+     * Sets the mass of the body. Inverse mass, density and inertia are automatically updated to reflect the change.
      * @method setMass
      * @param {body} body
      * @param {number} mass
@@ -293,7 +293,7 @@ var Axes = require('../geometry/Axes');
     };
 
     /**
-     * Sets the density of the body. Mass is automatically updated to reflect the change.
+     * Sets the density of the body. Mass and inertia are automatically updated to reflect the change.
      * @method setDensity
      * @param {body} body
      * @param {number} density


### PR DESCRIPTION
I'm not sure how setMass should be handled when body is sleeping or static. I guess it is a case that doesn't need to be handled perfectly.