### PR TITLE
Adding a new render option - "clearCanvas"

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -57,6 +57,7 @@ var Mouse = require('../core/Mouse');
                 hasBounds: !!options.bounds,
                 enabled: true,
                 wireframes: true,
+                clearCanvas: true,
                 showSleeping: true,
                 showDebug: false,
                 showBroadphase: false,
@@ -310,9 +311,13 @@ var Mouse = require('../core/Mouse');
             _applyBackground(render, background);
 
         // clear the canvas with a transparent fill, to allow the canvas background to show
-        context.globalCompositeOperation = 'source-in';
-        context.fillStyle = "transparent";
-        context.fillRect(0, 0, canvas.width, canvas.height);
+        if (options.clearCanvas) {
+            context.globalCompositeOperation = 'source-in';
+            context.fillStyle = "transparent";
+            context.fillRect(0, 0, canvas.width, canvas.height);
+        }
+
+        // set the canvas composition for rendering the the world
         context.globalCompositeOperation = 'source-over';
 
         // handle bounds


### PR DESCRIPTION
I have a use case where I would like to use the built in matter-js renderer for debug rendering of the physics world "ontop" of an existing canvas. I'm using another renderer for the actual sprites and other visuals displayed on the canvas element, and it would be nice to toggle on a physics debug to see collision bodies by leveraging the built in matter-js renderer. By disabling the "clearCanvas", I am then able to call Matter.Render.world() during my post render.