### PR TITLE
remove spelling mistake

### DIFF
--- a/demo/js/Demo.js
+++ b/demo/js/Demo.js
@@ -268,7 +268,7 @@
                 name: 'Terrain',
                 id: 'terrain',
                 init: Example.terrain,
-                sourceLink: sourceLinkRoot + '/terraing.js'
+                sourceLink: sourceLinkRoot + '/terrain.js'
             },
             {
                 name: 'Time Scaling',


### PR DESCRIPTION
the spelling mistake currently brings users to a 404 page, if he wants to access the code of the terrain demo.