### PR TITLE
Aglorithm optimization of Pairs.update method

### DIFF
--- a/src/collision/Pair.js
+++ b/src/collision/Pair.js
@@ -33,6 +33,7 @@ var Contact = require('./Contact');
             activeContacts: [],
             separation: 0,
             isActive: true,
+            confirmedActive: true,
             isSensor: bodyA.isSensor || bodyB.isSensor,
             timeCreated: timestamp,
             timeUpdated: timestamp,

--- a/src/collision/Pairs.js
+++ b/src/collision/Pairs.js
@@ -94,7 +94,7 @@ var Common = require('../core/Common');
         // deactivate previously active pairs that are now inactive
         for (i = 0; i < pairsList.length; i++) {
             pair = pairsList[i];
-            if (!pair.confirmedActive) {
+            if (pair.isActive && !pair.confirmedActive) {
                 Pair.setActive(pair, false, timestamp);
                 collisionEnd.push(pair);
             }

--- a/src/collision/Pairs.js
+++ b/src/collision/Pairs.js
@@ -55,12 +55,15 @@ var Common = require('../core/Common');
         collisionEnd.length = 0;
         collisionActive.length = 0;
 
+        for (i = 0; i < pairsList.length; i++) {
+          pairsList[i].confirmedActive = false;
+        }
+
         for (i = 0; i < collisions.length; i++) {
             collision = collisions[i];
 
             if (collision.collided) {
                 pairId = Pair.id(collision.bodyA, collision.bodyB);
-                activePairIds.push(pairId);
 
                 pair = pairsTable[pairId];
                 
@@ -76,6 +79,7 @@ var Common = require('../core/Common');
 
                     // update the pair
                     Pair.update(pair, collision, timestamp);
+                    pair.confirmedActive = true;
                 } else {
                     // pair did not exist, create a new pair
                     pair = Pair.create(collision, timestamp);
@@ -91,7 +95,7 @@ var Common = require('../core/Common');
         // deactivate previously active pairs that are now inactive
         for (i = 0; i < pairsList.length; i++) {
             pair = pairsList[i];
-            if (pair.isActive && Common.indexOf(activePairIds, pair.id) === -1) {
+            if (!pair.confirmedActive) {
                 Pair.setActive(pair, false, timestamp);
                 collisionEnd.push(pair);
             }

--- a/src/collision/Pairs.js
+++ b/src/collision/Pairs.js
@@ -44,7 +44,6 @@ var Common = require('../core/Common');
             collisionStart = pairs.collisionStart,
             collisionEnd = pairs.collisionEnd,
             collisionActive = pairs.collisionActive,
-            activePairIds = [],
             collision,
             pairId,
             pair,

--- a/src/collision/Pairs.js
+++ b/src/collision/Pairs.js
@@ -56,7 +56,7 @@ var Common = require('../core/Common');
         collisionActive.length = 0;
 
         for (i = 0; i < pairsList.length; i++) {
-          pairsList[i].confirmedActive = false;
+            pairsList[i].confirmedActive = false;
         }
 
         for (i = 0; i < collisions.length; i++) {


### PR DESCRIPTION
### Changes
Added a boolean on the `Pair` object that saves whether a pair has been confirmed as active at the current iteration.
The idea was to reduce the complexity of the second loop of the function from `O(n*m)` to `O(n)`. Where `n` is the number of pairs and `m` the number of active pairs.

### Result

Profiling on a specific test case indicated that the `indexOf` method was using about 13% of CPU resources used by the `matterjs`:
<img width="427" alt="screen shot 2017-11-20 at 11 46 57 am" src="https://user-images.githubusercontent.com/1897225/33107469-c01c5266-cf7a-11e7-894c-f115eac3697b.png">
We can notice that the `Pairs.update` method is consuming 27% of the total.

After the optimization the profiling looks like this:
<img width="423" alt="screen shot 2017-11-20 at 11 46 33 am" src="https://user-images.githubusercontent.com/1897225/33107564-23366292-cf7b-11e7-93bf-b0073979b157.png">

Notice that the `indexOf` method disappeared and the `Pairs.update` method is now consuming only 16% of the total.
Overall the engine is ~13% faster on that particular test case (about 50 bodies). The benefit should get bigger as the number of bodies in the world increase.