### PR TITLE
Optimization of Resolver.solvePosition method

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -49,6 +49,7 @@ var Axes = require('../geometry/Axes');
             force: { x: 0, y: 0 },
             torque: 0,
             positionImpulse: { x: 0, y: 0 },
+            previousPositionImpulse: { x: 0, y: 0 },
             constraintImpulse: { x: 0, y: 0, angle: 0 },
             totalContacts: 0,
             speed: 0,

--- a/src/collision/Resolver.js
+++ b/src/collision/Resolver.js
@@ -50,21 +50,31 @@ var Bounds = require('../geometry/Bounds');
      * @param {pair[]} pairs
      * @param {number} timeScale
      */
-    Resolver.solvePosition = function(pairs, timeScale) {
+    Resolver.solvePosition = function(pairs, bodies, timeScale) {
         var i,
+            normalX,
+            normalY,
             pair,
             collision,
             bodyA,
             bodyB,
             normal,
-            bodyBtoA,
+            separation,
+            penetration,
+            positionImpulseA,
+            positionImpulseB,
             contactShare,
+            bodyBtoAX,
+            bodyBtoAY,
             positionImpulse,
-            contactCount = {},
-            tempA = Vector._temp[0],
-            tempB = Vector._temp[1],
-            tempC = Vector._temp[2],
-            tempD = Vector._temp[3];
+            impulseCoefficient = timeScale * Resolver._positionDampen;
+
+
+        for (i = 0; i < bodies.length; i++) {
+            var body = bodies[i];
+            body.previousPositionImpulse.x = body.positionImpulse.x;
+            body.previousPositionImpulse.y = body.positionImpulse.y;
+        }
 
         // find impulses required to resolve penetration
         for (i = 0; i < pairs.length; i++) {
@@ -78,42 +88,41 @@ var Bounds = require('../geometry/Bounds');
             bodyB = collision.parentB;
             normal = collision.normal;
 
-            // get current separation between body edges involved in collision
-            bodyBtoA = Vector.sub(Vector.add(bodyB.positionImpulse, bodyB.position, tempA), 
-                                    Vector.add(bodyA.positionImpulse, 
-                                        Vector.sub(bodyB.position, collision.penetration, tempB), tempC), tempD);
+            positionImpulseA = bodyA.previousPositionImpulse;
+            positionImpulseB = bodyB.previousPositionImpulse;
 
-            pair.separation = Vector.dot(normal, bodyBtoA);
-        }
-        
-        for (i = 0; i < pairs.length; i++) {
-            pair = pairs[i];
+            penetration = collision.penetration;
 
-            if (!pair.isActive || pair.isSensor)
-                continue;
-            
-            collision = pair.collision;
-            bodyA = collision.parentA;
-            bodyB = collision.parentB;
-            normal = collision.normal;
-            positionImpulse = (pair.separation - pair.slop) * timeScale;
+            // bodyBtoA = positionImpulseB - positionImpulseA + penetration
+            bodyBtoAX = positionImpulseB.x - positionImpulseA.x + penetration.x;
+            bodyBtoAY = positionImpulseB.y - positionImpulseA.y + penetration.y;
+
+            normalX = normal.x;
+            normalY = normal.y;
+
+            // separation = dot(normal, bodyBtoA)
+            separation = normalX * bodyBtoAX + normalY * bodyBtoAY;
+            pair.separation = separation;
+
+            positionImpulse = (separation - pair.slop) * impulseCoefficient;
 
             if (bodyA.isStatic || bodyB.isStatic)
                 positionImpulse *= 2;
             
             if (!(bodyA.isStatic || bodyA.isSleeping)) {
-                contactShare = Resolver._positionDampen / bodyA.totalContacts;
-                bodyA.positionImpulse.x += normal.x * positionImpulse * contactShare;
-                bodyA.positionImpulse.y += normal.y * positionImpulse * contactShare;
+                contactShare = positionImpulse / bodyA.totalContacts;
+                bodyA.positionImpulse.x += normalX * contactShare;
+                bodyA.positionImpulse.y += normalY * contactShare;
             }
 
             if (!(bodyB.isStatic || bodyB.isSleeping)) {
-                contactShare = Resolver._positionDampen / bodyB.totalContacts;
-                bodyB.positionImpulse.x -= normal.x * positionImpulse * contactShare;
-                bodyB.positionImpulse.y -= normal.y * positionImpulse * contactShare;
+                contactShare = positionImpulse / bodyB.totalContacts;
+                bodyB.positionImpulse.x -= normalX * contactShare;
+                bodyB.positionImpulse.y -= normalY * contactShare;
             }
         }
     };
+
 
     /**
      * Apply position resolution.

--- a/src/core/Engine.js
+++ b/src/core/Engine.js
@@ -195,7 +195,7 @@ var Body = require('../body/Body');
         // iteratively resolve position between collisions
         Resolver.preSolvePosition(pairs.list);
         for (i = 0; i < engine.positionIterations; i++) {
-            Resolver.solvePosition(pairs.list, timing.timeScale);
+            Resolver.solvePosition(pairs.list, allBodies, timing.timeScale);
         }
         Resolver.postSolvePosition(allBodies);
 


### PR DESCRIPTION
### Changes
- Bodies now stored their previous position impulse (increasing memory footprint)
- The `Resolver.update` method now loops through the pair of collisions only once, but also loop through the bodies in order to reset position impulses - the idea was to avoid looping through the pair twice because of the computation overhead.
- One vector operation was simplified, used to be:
`bodyBtoA = (positionImpulseB + positionB) - (positionImpulseA + positionB - penetration)`
simplified to:
`bodyBtoA = positionImpulseB - positionImpulseA + penetration`
- Bypassing the `Vector` API for performance boost.

### Result
I used the **CircleStack** demo to do the following performance test.
On this particular demo, the `solvePosition` method seems to be more than 10x faster now:

Before:
<img width="418" alt="screen shot 2017-11-24 at 5 48 05 pm" src="https://user-images.githubusercontent.com/1897225/33202396-baeb28be-d13f-11e7-92ba-0f988b506a6a.png">

After:
<img width="429" alt="screen shot 2017-11-24 at 5 47 20 pm" src="https://user-images.githubusercontent.com/1897225/33202404-c064d4de-d13f-11e7-9ca3-f0d089acd381.png">

We can see a dramatic fall for the `Resolver.solvePosition` method in the ranking of top consuming methods (from 3rd place to something like 20th place!).

Speed up greatly varies depending on the complexity of the world. Usually, the more objects collide the greater the speed up.