### PR TITLE
#544 Replace references to global Matter in Composite.bounds()

### DIFF
--- a/src/body/Composite.js
+++ b/src/body/Composite.js
@@ -16,6 +16,7 @@ module.exports = Composite;
 var Events = require('../core/Events');
 var Common = require('../core/Common');
 var Body = require('./Body');
+var Bounds = require('../geometry/Bounds');
 
 (function() {
 
@@ -539,7 +540,7 @@ var Body = require('./Body');
      * @returns {bounds} The composite bounds.
      */
     Composite.bounds = function(composite) {
-        var bodies = Matter.Composite.allBodies(composite),
+        var bodies = Composite.allBodies(composite),
             vertices = [];
 
         for (var i = 0; i < bodies.length; i += 1) {
@@ -547,7 +548,7 @@ var Body = require('./Body');
             vertices.push(body.bounds.min, body.bounds.max);
         }
 
-        return Matter.Bounds.create(vertices);
+        return Bounds.create(vertices);
     };
 
     /*


### PR DESCRIPTION
Replaces stray `Matter.{module}` with in-scope `require`d equivalents.