### PR TITLE
Fix bug of  Common.isElement

### DIFF
--- a/src/core/Common.js
+++ b/src/core/Common.js
@@ -181,7 +181,7 @@ module.exports = Common;
             return obj instanceof HTMLElement;
         }
 
-        return !!(obj.nodeType && obj.nodeName);
+        return !!(obj && obj.nodeType && obj.nodeName);
     };
 
     /**


### PR DESCRIPTION
When HTMLElement is not exist (in webworker) , and obj is null/undefined , current version will take a error.
