### PR TITLE
Optimized Events.trigger method when no event is emitted

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -84,7 +84,8 @@ var Common = require('./Common');
             callbacks,
             eventClone;
 
-        if (object.events) {
+        var events = object.events;
+        if (events && Object.keys(events).length > 0) {
             if (!event)
                 event = {};
 
@@ -92,7 +93,7 @@ var Common = require('./Common');
 
             for (var i = 0; i < names.length; i++) {
                 name = names[i];
-                callbacks = object.events[name];
+                callbacks = events[name];
 
                 if (callbacks) {
                     eventClone = Common.clone(event, false);


### PR DESCRIPTION
For my particular use case the `Events.trigger` method was taking roughly 5% of the resources of the physics engine even though no event was emitted. This brings it down to >1%.

It is a small overhead when events are used though. However I think that one sound logic is to accept overhead for optimizing out optional features as they will rarely all be used.