### PR TITLE
Offer the optimal decomp function instead of just the quick one. (poly-decomp

### DIFF
--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -218,6 +218,7 @@ var decomp;
         flagInternal = typeof flagInternal !== 'undefined' ? flagInternal : false;
         removeCollinear = typeof removeCollinear !== 'undefined' ? removeCollinear : 0.01;
         minimumArea = typeof minimumArea !== 'undefined' ? minimumArea : 10;
+        quick = typeof quick !== 'undefined' ? quick : true;
 
         if (!decomp) {
             Common.warn('Bodies.fromVertices: poly-decomp.js required. Could not decompose vertices. Fallback to convex hull.');

--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -181,7 +181,7 @@ var decomp;
      * If the vertices are convex, they will pass through as supplied.
      * Otherwise if the vertices are concave, they will be decomposed if [poly-decomp.js](https://github.com/schteppe/poly-decomp.js) is available.
      * Note that this process is not guaranteed to support complex sets of vertices (e.g. those with holes may fail).
-     * By default the decomposition will discard collinear edges (to improve performance).
+     * By default the decomposition will discard collinear edges and run quickDecomp (to improve performance).
      * It can also optionally discard any parts that have an area less than `minimumArea`.
      * If the vertices can not be decomposed, the result will fall back to using the convex hull.
      * The options parameter is an object that specifies any `Matter.Body` properties you wish to override the defaults.
@@ -194,9 +194,10 @@ var decomp;
      * @param {bool} [flagInternal=false]
      * @param {number} [removeCollinear=0.01]
      * @param {number} [minimumArea=10]
+     * @param {number} [quick=true]
      * @return {body}
      */
-    Bodies.fromVertices = function(x, y, vertexSets, options, flagInternal, removeCollinear, minimumArea) {
+    Bodies.fromVertices = function(x, y, vertexSets, options, flagInternal, removeCollinear, minimumArea, quick) {
         if (!decomp) {
             decomp = Common._requireGlobal('decomp', 'poly-decomp');
         }
@@ -254,8 +255,12 @@ var decomp;
                 if (removeCollinear !== false)
                     decomp.removeCollinearPoints(concave, removeCollinear);
 
-                // use the quick decomposition algorithm (Bayazit)
-                var decomposed = decomp.quickDecomp(concave);
+                // use the quick decomposition algorithm (Bayazit) or not
+                if (quick !== false) {
+                    decomp.removeCollinearPoints(concave, removeCollinear);
+                } else {
+                    var decomposed = decomp.decomp(concave);
+                }
 
                 // for each decomposed chunk
                 for (i = 0; i < decomposed.length; i++) {

--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -258,7 +258,7 @@ var decomp;
 
                 // use the quick decomposition algorithm (Bayazit) or not
                 if (quick !== false) {
-                    decomp.removeCollinearPoints(concave, removeCollinear);
+                    var decomposed = decomp.quickDecomp(concave);
                 } else {
                     var decomposed = decomp.decomp(concave);
                 }


### PR DESCRIPTION
In some case situations, my polygons might get a lot of vertices etc... ( I'm making a worms like game and map destruction is possible. ) I was running into the issue with poly-decomp: 'Error: quickDecomp: max level (100) reached.' Which seems to have been fixed when I changed the source to not run quickDecomp but instead run decomp. While I understand why one would like to use the quick function, this allows both options.