### PR TITLE
fix air friction calculation

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -602,10 +602,11 @@ var Axes = require('../geometry/Axes');
      * @param {number} correction
      */
     Body.update = function(body, deltaTime, timeScale, correction) {
-        var deltaTimeSquared = Math.pow(deltaTime * timeScale * body.timeScale, 2);
+        var deltaTimeScaled = deltaTime * timeScale * body.timeScale;
+        var deltaTimeSquared = Math.pow(deltaTimeScaled, 2);
 
         // from the previous step
-        var frictionAir = 1 - body.frictionAir * timeScale * body.timeScale,
+        var frictionAir = 1 - body.frictionAir * deltaTimeScaled / body.mass,
             velocityPrevX = body.position.x - body.positionPrev.x,
             velocityPrevY = body.position.y - body.positionPrev.y;
 


### PR DESCRIPTION
The code is slghtliy confusing because `velocityPrevX` and `velocityPrevY` actually define a distance. The real velocity can be calculated as `velocityPrevX / deltaTimePrev` and `velocityPrev / deltaTimePrev` where `deltaTimePrev = deltaTimeScaled / correction`.

This is the formular without air friction:

```
velocity.x = velocityPrevX * correction + body.force.x / body.mass * deltaTimeSquared
```

Air friction is a force that acts in the opposite direction of the velocity. It is proportional to velocity (for small velocity):

```
var force = body.force.x - (body.frictionAir * velocityPrevX / deltaTimeScaled * correction);
velocity.x = velocityPrevX * correction + force / body.mass * deltaTimeSquared;
```

which can be converted to:

```
var frictionAir = 1 - body.frictionAir * deltaTimeScaled / body.mass;
velocity.x = velocityPrevX * frictionAir * correction + body.force.x / body.mass * deltaTimeSquared;
```