### PR TITLE
Adds support for Mouse on SVG elements

### DIFF
--- a/src/core/Mouse.js
+++ b/src/core/Mouse.js
@@ -182,6 +182,8 @@ var Common = require('../core/Common');
             scrollX = (window.pageXOffset !== undefined) ? window.pageXOffset : rootNode.scrollLeft,
             scrollY = (window.pageYOffset !== undefined) ? window.pageYOffset : rootNode.scrollTop,
             touches = event.changedTouches,
+            elementWidth = element.width || element.clientWidth,
+            elementHeight = element.height || element.clientHeight,
             x, y;
         
         if (touches) {
@@ -192,9 +194,14 @@ var Common = require('../core/Common');
             y = event.pageY - elementBounds.top - scrollY;
         }
 
+        if (elementWidth.animVal) {
+            elementWidth = elementWidth.animVal.value;
+            elementHeight = elementHeight.animVal.value;
+        }
+
         return { 
-            x: x / (element.clientWidth / (element.width || element.clientWidth) * pixelRatio),
-            y: y / (element.clientHeight / (element.height || element.clientHeight) * pixelRatio)
+            x: x / (element.clientWidth / elementWidth * pixelRatio),
+            y: y / (element.clientHeight / elementHeight * pixelRatio)
         };
     };
 


### PR DESCRIPTION
SVG elements have `.width` and `.height` as SVGAnimatedLength types, and we need to retrieve the current value from `.width.animVal.value`. This allows `Matter.Mouse.create()` to be called with an SVG element instead of a div or canvas.