### PR TITLE
Improved testing and comparison tooling

### DIFF
--- a/examples/avalanche.js
+++ b/examples/avalanche.js
@@ -1,10 +1,10 @@
 var Example = Example || {};
 
-Matter.use(
-    'matter-wrap'
-);
-
 Example.avalanche = function() {
+    Matter.use(
+        'matter-wrap'
+    );
+    
     var Engine = Matter.Engine,
         Render = Matter.Render,
         Runner = Matter.Runner,

--- a/examples/ballPool.js
+++ b/examples/ballPool.js
@@ -1,10 +1,10 @@
 var Example = Example || {};
 
-Matter.use(
-    'matter-wrap'
-);
-
 Example.ballPool = function() {
+    Matter.use(
+        'matter-wrap'
+    );
+    
     var Engine = Matter.Engine,
         Render = Matter.Render,
         Runner = Matter.Runner,

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "gulp-tag-version": "^1.3.0",
     "gulp-util": "^3.0.8",
     "jest": "^24.9.0",
+    "jest-worker": "^24.9.0",
     "json-stringify-pretty-compact": "^2.0.0",
     "run-sequence": "^1.1.4",
     "webpack": "^4.39.3",
@@ -38,10 +39,11 @@
     "build": "webpack --mode=production & webpack --mode=production --env.MINIMIZE",
     "build-alpha": "webpack --mode=production --env.EDGE & webpack --mode=production --env.MINIMIZE --env.EDGE",
     "build-examples": "webpack --config webpack.examples.config.js --mode=production --env.EDGE & webpack --config webpack.examples.config.js --mode=production --env.MINIMIZE --env.EDGE",
-    "lint": "eslint 'src/**/*.js' 'demo/js/Demo.js' 'demo/js/Compare.js' 'examples/*.js' 'test/*.spec.js' 'webpack.*.js' 'Gulpfile.js'",
+    "lint": "eslint 'src/**/*.js' 'demo/js/Demo.js' 'demo/js/Compare.js' 'examples/*.js' 'webpack.*.js' 'Gulpfile.js'",
     "doc": "gulp doc",
     "test": "jest",
-    "compare": "COMPARE=true jest"
+    "test-save": "SAVE=true jest",
+    "test-watch": "jest --watch"
   },
   "dependencies": {},
   "files": [

--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -196,7 +196,7 @@ var Vector = require('../geometry/Vector');
      * @return {body}
      */
     Bodies.fromVertices = function(x, y, vertexSets, options, flagInternal, removeCollinear, minimumArea) {
-        var decomp = typeof decomp !== 'undefined' ? decomp : require('poly-decomp'),
+        var decomp = global.decomp || require('poly-decomp'),
             body,
             parts,
             isConvex,

--- a/test/ExampleWorker.js
+++ b/test/ExampleWorker.js
@@ -21,7 +21,7 @@ const reset = M => {
 
 const { engineCapture } = require('./TestTools');
 const MatterDev = stubBrowserFeatures(require('../src/module/main'));
-const MatterBuild = stubBrowserFeatures(require('../build/Matter'));
+const MatterBuild = stubBrowserFeatures(require('../build/matter'));
 const Example = require('../examples/index');
 const decomp = require('../demo/lib/decomp');
 

--- a/test/ExampleWorker.js
+++ b/test/ExampleWorker.js
@@ -1,0 +1,61 @@
+/* eslint-env es6 */
+/* eslint no-global-assign: 0 */
+"use strict";
+
+const stubBrowserFeatures = M => {
+  const noop = () => ({ collisionFilter: {}, mouse: {} });
+  M.Render.create = () => ({ options: {}, bounds: { min: { x: 0, y: 0 }, max: { x: 800, y: 600 }}});
+  M.Render.run = M.Render.lookAt = noop;
+  M.Runner.create = M.Runner.run = noop;
+  M.MouseConstraint.create = M.Mouse.create = noop;
+  M.Common.log = M.Common.info = M.Common.warn = noop;
+  return M;
+};
+
+const reset = M => {
+  M.Common._nextId = M.Common._seed = 0;
+  M.Body._nextCollidingGroupId = 1;
+  M.Body._nextNonCollidingGroupId = -1;
+  M.Body._nextCategory = 0x0001;
+};
+
+const { engineCapture } = require('./TestTools');
+const MatterDev = stubBrowserFeatures(require('../src/module/main'));
+const MatterBuild = stubBrowserFeatures(require('../build/Matter'));
+const Example = require('../examples/index');
+const decomp = require('../demo/lib/decomp');
+
+const runExample = options => {
+  const Matter = options.useDev ? MatterDev : MatterBuild;
+  const consoleOriginal = global.console;
+
+  global.console = { log: () => {} };
+  global.document = {};
+  global.decomp = decomp;
+  global.Matter = Matter;
+
+  reset(Matter);
+
+  const example = Example[options.name]();
+  const engine = example.engine;
+  const startTime = process.hrtime();
+
+  for (let i = 0; i < options.totalUpdates; i += 1) {
+      Matter.Engine.update(engine, 1000 / 60);
+  }
+
+  const duration = process.hrtime(startTime);
+
+  global.console = consoleOriginal;
+  global.document = undefined;
+  global.decomp = undefined;
+  global.Matter = undefined;
+
+  return {
+    name: options.name,
+    duration: duration[0] * 1e9 + duration[1],
+    ...engineCapture(engine)
+  };
+};
+
+module.exports = { runExample };


### PR DESCRIPTION
I've been working on new tools to help review the result of any changes made to the codebase.

The new comparison tool is essentially an integration test which runs all of the examples using the current source and compares results against the latest release build. It produces a report flagging any:

- runtime errors
- intrinsic changes (mass, intertia, friction etc.)
- extrinsic changes (position, angle, velocity)
- performance changes

Intrinsic properties generally shouldn't change (other than new properties) as this would indicate a likely regression, or at least a breaking change. For example, the `mass` of the same body should never change between versions.

Extrinsic properties may change as they may have multiple acceptable values due to limited simulation accuracy. They indicate a change to the simulation behaviour, which may be acceptable and intended or may not be. For example, the `position` of the same body may change between versions if an accuracy improvement was since implemented. Whereas a code refactor for example, should not normally change the resulting extrinsic properties between versions.

It's possible for example that a performance refactor might come with an accuracy trade-off that changes extrinsic properties whilst producing acceptable results. Generally extrinsic changes will require some further manual testing and review before deeming acceptance into the build (the visual comparison tool below can help with judging the difference).

Here's how to run the comparison integration test (included as part of the test suite):

`npm run test` or `npm run test-watch`

<img width="902" alt="matter-compare-test" src="https://user-images.githubusercontent.com/654420/68434752-a9ede200-01b1-11ea-9cf0-332961002128.png">

There is also a new browser-based visual comparison tool that runs both versions side by side and overlays both interactive simulations in real-time for comparing extrinsic changes. Below you can see how the catapult example behaviour quickly diverges from release version when the default friction is changed.

`open http://localhost:8000/?compare=120#catapult`

![matter-compare-extrinsic](https://user-images.githubusercontent.com/654420/68434862-eb7e8d00-01b1-11ea-8268-2d2c92ab86ae.gif)

To visualise intrinsic changes, the tool can output them into two separate files for each version which can then be diff'd e.g. using vscode.

`npm run test-save`
`code -n -d test/__compare__/examples-build.json test/__compare__/examples-dev.json`

<img width="1040" alt="matter-compare-intrinsic" src="https://user-images.githubusercontent.com/654420/68434947-1cf75880-01b2-11ea-80d3-024692bb5d0c.png">

This approach is still experimental, so it will take some time to see how useful it is in practice. I might also add code size comparison too. If anybody has ideas on other improvements for this, feel free to post them here. Thanks.