### PR TITLE
use Common.extend() in Constraint

### DIFF
--- a/src/constraint/Constraint.js
+++ b/src/constraint/Constraint.js
@@ -49,7 +49,7 @@ var Common = require('../core/Common');
         var initialPointA = constraint.bodyA ? Vector.add(constraint.bodyA.position, constraint.pointA) : constraint.pointA,
             initialPointB = constraint.bodyB ? Vector.add(constraint.bodyB.position, constraint.pointB) : constraint.pointB,
             length = Vector.magnitude(Vector.sub(initialPointA, initialPointB));
-    
+
         constraint.length = typeof constraint.length !== 'undefined' ? constraint.length : length;
 
         // option defaults
@@ -157,7 +157,7 @@ var Common = require('../core/Common');
             Vector.rotate(pointA, bodyA.angle - constraint.angleA, pointA);
             constraint.angleA = bodyA.angle;
         }
-        
+
         // update reference angle
         if (bodyB && !bodyB.isStatic) {
             Vector.rotate(pointB, bodyB.angle - constraint.angleB, pointB);
@@ -235,7 +235,7 @@ var Common = require('../core/Common');
             // keep track of applied impulses for post solving
             bodyB.constraintImpulse.x += force.x * share;
             bodyB.constraintImpulse.y += force.y * share;
-            
+
             // apply forces
             bodyB.position.x += force.x * share;
             bodyB.position.y += force.y * share;
@@ -274,7 +274,7 @@ var Common = require('../core/Common');
             // update geometry and reset
             for (var j = 0; j < body.parts.length; j++) {
                 var part = body.parts[j];
-                
+
                 Vertices.translate(part.vertices, impulse);
 
                 if (j > 0) {
@@ -390,7 +390,7 @@ var Common = require('../core/Common');
      */
 
     /**
-     * A `String` that defines the constraint rendering type. 
+     * A `String` that defines the constraint rendering type.
      * The possible values are 'line', 'pin', 'spring'.
      * An appropriate render type will be automatically chosen unless one is given in options.
      *
@@ -450,7 +450,7 @@ var Common = require('../core/Common');
      */
 
     /**
-     * A `Number` that specifies the damping of the constraint, 
+     * A `Number` that specifies the damping of the constraint,
      * i.e. the amount of resistance applied to each body based on their velocities to limit the amount of oscillation.
      * Damping will only be apparent when the constraint also has a very low `stiffness`.
      * A value of `0.1` means the constraint will apply heavy damping, resulting in little to no oscillation.
@@ -462,7 +462,7 @@ var Common = require('../core/Common');
      */
 
     /**
-     * A `Number` that specifies the target resting length of the constraint. 
+     * A `Number` that specifies the target resting length of the constraint.
      * It is calculated automatically in `Constraint.create` from initial positions of the `constraint.bodyA` and `constraint.bodyB`.
      *
      * @property length

--- a/src/constraint/Constraint.js
+++ b/src/constraint/Constraint.js
@@ -37,7 +37,10 @@ var Common = require('../core/Common');
      * @return {constraint} constraint
      */
     Constraint.create = function(options) {
-        var constraint = options;
+        var defaults = {
+        };
+
+        var constraint = Common.extend(defaults, false, options);
 
         // if bodies defined but no points, use body centre
         if (constraint.bodyA && !constraint.pointA)


### PR DESCRIPTION
this should allow specifying `plugin` among others in `Constraint.create()`.

See #817.

---

Sadly I do have basically two questions. First, running `npm install` and then `npm run test` gave me errors about missing `poly-decomp` so I added that. Is that a missing dependency? The demos seemed to run fine without it.

Second: right now I just tried to add in a dummy `extend` call, like this:

    var defaults = {
    };

    var constraint = Common.extend(defaults, options);

This leads to a stack overflow, as the options (maybe `bodyA` or `bodyB`?) seem to be recursive. Using `Common.extend(defaults, false, options);` works, but I'm not sure what the ultimate consequences of that would be. I presume not different from the current `var constraint = options;` so I'll go ahead, but I still wanted to ask your opinion on that.