### PR TITLE
Improve collision event support for common scenarios (minimal "kinematic bodies" support)

### DIFF
--- a/src/collision/Detector.js
+++ b/src/collision/Detector.js
@@ -35,7 +35,7 @@ var Bounds = require('../geometry/Bounds');
             var bodyA = broadphasePairs[i][0], 
                 bodyB = broadphasePairs[i][1];
 
-            if ((bodyA.isStatic || bodyA.isSleeping) && (bodyB.isStatic || bodyB.isSleeping))
+            if (bodyA.isSleeping && bodyB.isSleeping)
                 continue;
             
             if (!Detector.canCollide(bodyA.collisionFilter, bodyB.collisionFilter))

--- a/src/collision/Grid.js
+++ b/src/collision/Grid.js
@@ -243,7 +243,10 @@ var Common = require('../core/Common');
         for (var i = 0; i < bucket.length; i++) {
             var bodyB = bucket[i];
 
-            if (body.id === bodyB.id || (body.isStatic && bodyB.isStatic))
+            if (body.id === bodyB.id)
+                continue;
+
+            if (body.isStatic && bodyB.isStatic && !(body.isSensor || bodyB.isSensor))
                 continue;
 
             // keep track of the number of buckets the pair exists in


### PR DESCRIPTION
This PR allows static bodies to collide with each other, on the condition that at least one of the two is a sensor. It also allows static bodies to collide with sleeping bodies, though the latter won't automatically wake on such a collision. (They can just be woken in the collision event if needed; I do think it might be more intuitive for non-sensor static bodies to wake sleeping bodies automatically, but I'm not sure if that might carry undesirable side effects.)

### Rationale

In games, even ones where the gameplay is heavily driven by physics, it's often desirable to be able to have full control over some physics bodies by removing the effect of simulation forces like gravity, drag, inertia, etc. on them. Some motion in games is highly unrealistic, so "doing one's own bookkeeping" on it can be more simple, predictable, and easy for designers to tweak than trying to wrestle with simulation properties. For example, in a game like Super Mario Bros you may want to limit terminal velocity to an explicit, fairly low value to allow players a chance to react even if they drop from a great height; or if the player bounces off a turtle you might not want to transfer momentum in a typical way.

That said, it's also often desirable for these manually-controlled bodies to continue to participate in the simulation in some way. If a simulation-driven rock falls on a character we may want them to take damage or otherwise react in some way; characters with [skeletal animation](https://docs.godotengine.org/en/stable/_images/tuto_cutout_walk.gif) may ["ragdoll"](https://q5q6q2e3.stackpathcdn.com/wp-content/uploads/2019/12/unity-rag-doll-example.gif) and allow the simulation to dictate their motion. At a more basic level, it's useful to be able to reuse existing collision systems, events, and idioms rather than implement additional detection, spatial partitioning, etc., for this other class of objects.

Box2D, PhysX and other physics engines usually refer to this type of body as "kinematic," and it's [one of the most upvoted issues](https://github.com/liabru/matter-js/issues/498) for this repo. But Matter already has something very similar in `isStatic`: manually driving static bodies is very well-behaved, as the [manipulation demo](http://brm.io/matter-js/demo/#manipulation) shows. The only thing missing is that currently only non-static bodies trigger events with static bodies, making it difficult to handle, say, the platform game case of an `isStatic` player character jumping on an `isStatic` enemy.

This PR resolves this by allowing pairs of static bodies to be candidates on the broadphase grid, as long as at least one of them is a sensor. This seemed like a reasonable compromise between allowing the necessary affordances for kinematic control without incurring too much of a performance penalty. It also removes an early out case in `Detector.collisions` (afaict never hit because of the broadphase condition) preventing two static bodies from colliding, and resolves an edge case where there wasn't really a sensible way for static bodies to wake sleeping dynamic bodies (fixes #875).

### Alternatives

- The [Phaser](https://phaser.io/) game framework, which now bundles Matter, seems to suggest getting around this by doing stuff like [zeroing out gravity and setting inertia on bodies to infinity](https://labs.phaser.io/edit.html?src=src/physics/matterjs/compound%20sensors.js&v=3.23.0). This seems more inefficient -- since rather than telling the engine to not bother trying to apply forces, we're instead setting parameters high enough to make them moot -- and I worry it could lead to unexpected behaviour or simulation instability. It's also kind of inconvenient to have to zero out gravity and apply it ourselves, all else being equal.

- Rather than making this new behaviour the default for static bodies, we could instead add a new per-body flag to opt-in to collisions with other static bodies. I think the "at least one sensor" approach of this PR is a good default, but a flag to allow non-sensor static bodies to collide with other non-sensor static bodies could still be useful. (Unity's 2D physics system, which is based on Box2D, has a per-body flag called "use full kinematic contacts" which does just this:)
![Screenshot from 2020-05-16 23-04-04](https://user-images.githubusercontent.com/567041/82138650-03356e80-97f0-11ea-80c2-a8064e135c74.png)

- Rather than apply this behaviour to `isStatic` bodies, we could introduce a new kinematic body type. This doesn't seem super necessary to me, but it might make sense if there was further optimization work done on `isStatic`, such that it became a flag for bodies that were intended to never be moved or moved only infrequently. (It might also help alleviate some of the questions that come up in the issue tracker about kinematic bodies -- but updating demos or adding a bit more documentation could do that too.)

Hope this is helpful discussion! Sorry for the wall of text for such a tiny PR.