### PR TITLE
Fix potential typo in docs

### DIFF
--- a/src/core/Runner.js
+++ b/src/core/Runner.js
@@ -197,7 +197,7 @@ var Common = require('./Common');
 
     /**
      * Ends execution of `Runner.run` on the given `runner`, by canceling the animation frame request event loop.
-     * If you wish to only temporarily pause the engine, see `engine.enabled` instead.
+     * If you wish to only temporarily pause the engine, see `runner.enabled` instead.
      * @method stop
      * @param {runner} runner
      */


### PR DESCRIPTION
I saw "see `engine.enabled` instead" while I was reading the documentation but when I checked there was no `engine.enabled`. I think it was meant to be `runner.enabled`?