### PR TITLE
Fix event.off not removing callback

### DIFF
--- a/src/core/Events.js
+++ b/src/core/Events.js
@@ -62,7 +62,7 @@ var Common = require('./Common');
 
             if (callback && callbacks) {
                 for (var j = 0; j < callbacks.length; j++) {
-                    if (callbacks[j] !== callback)
+                    if (callbacks[j].toString() !== callback.toString())
                         newCallbacks.push(callbacks[j]);
                 }
             }
@@ -85,7 +85,7 @@ var Common = require('./Common');
             eventClone;
 
         var events = object.events;
-        
+
         if (events && Common.keys(events).length > 0) {
             if (!event)
                 event = {};


### PR DESCRIPTION
hey there, I was using Events module, but I wasn't enabled to remove a callback passing it as an argument, the only way to remove it, was to remove all the events calling Events.off( object,  eventName ), so after reviewing the Events module I found the issue, so base in [this](https://stackoverflow.com/questions/12216540/how-to-test-for-equality-of-functions-in-javascript/21680065) the correct way to check if two functions are equal is first to parse them as a string, and then compare if the results are equal. So I just modified one line of the module converting the callbacks to string in the if statement (line 65)

here is part of my code if it is needed to replicate the issue 

```
const update = function(e){
        console.log('working');
    }
    
    const {currentSelection} = props.editorData;
    useEffect(
        () => {



            console.log(runner);
            const $inspector = inspectorElem.current;
            if(currentSelection){
                setFormDisabled(false);
                set_initial_inspector($inspector, currentSelection);
                Matter.Events.on(runner, 'afterUpdate', update);

            }
            else{
                setFormDisabled(true);
                clearInspector($inspector);

                if(runner.events != null){
                     Matter.Events.off(runner, 'afterUpdate', update)
                }

            }
        },
        [currentSelection]
    );
```