### PR TITLE
Added tabindex to canvas

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -1472,6 +1472,7 @@ var Mouse = require('../core/Mouse');
         canvas.height = height;
         canvas.oncontextmenu = function() { return false; };
         canvas.onselectstart = function() { return false; };
+        canvas.tabindex = 1;
         return canvas;
     };
 


### PR DESCRIPTION
This allows for keyboard inputs to only be detected while the canvas is in focus. This could be useful for someone making a game built on Matter, that allows for comments or other input fields on the same page as the game.