### PR TITLE
Added tabIndex to canvas defaults 

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -1472,6 +1472,7 @@ var Mouse = require('../core/Mouse');
         canvas.height = height;
         canvas.oncontextmenu = function() { return false; };
         canvas.onselectstart = function() { return false; };
+        canvas.tabIndex = 1;
         return canvas;
     };
 


### PR DESCRIPTION
This will allow for in-focus keyboard input without needing to wrap the renderer or use and DOM queries to append it. This separates the canvas as a focusable element, meaning that a single page could have keyboard-controlled canvas rendering and textareas or other keyboard inputs without conflict.