### PR TITLE
Fix Mouse inaccuracy when pixelRatio is not int

### DIFF
--- a/src/core/Mouse.js
+++ b/src/core/Mouse.js
@@ -34,7 +34,7 @@ var Common = require('../core/Common');
         mouse.scale = { x: 1, y: 1 };
         mouse.wheelDelta = 0;
         mouse.button = -1;
-        mouse.pixelRatio = parseInt(mouse.element.getAttribute('data-pixel-ratio'), 10) || 1;
+        mouse.pixelRatio = mouse.element.getAttribute('data-pixel-ratio') || 1;
 
         mouse.sourceEvents = {
             mousemove: null,
@@ -192,9 +192,13 @@ var Common = require('../core/Common');
             y = event.pageY - elementBounds.top - scrollY;
         }
 
-        return { 
-            x: x / (element.clientWidth / (element.width || element.clientWidth) * pixelRatio),
-            y: y / (element.clientHeight / (element.height || element.clientHeight) * pixelRatio)
+        return {
+            x: parseInt(
+                x / (element.clientWidth / (element.width || element.clientWidth) * pixelRatio)
+                , 10),
+            y: parseInt(
+                y / (element.clientHeight / (element.height || element.clientHeight) * pixelRatio)
+                , 10)
         };
     };
 


### PR DESCRIPTION
When a pixel ratio is set by Renderer.setPixelRatio, the Mouse function automatically converts it to a integer. That creates a big inaccuracy when calculating the screen coordinates.

setPixelRatio('auto') can set a float value and those decimal will be ignored when calculating the mouse coordinates.