### PR TITLE
Added beginRender lifecycle event.

### DIFF
--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -348,6 +348,8 @@ var Mouse = require('../core/Mouse');
         context.fillRect(0, 0, canvas.width, canvas.height);
         context.globalCompositeOperation = 'source-over';
 
+        Events.trigger(render, "beginRender", event);
+
         // handle bounds
         if (options.hasBounds) {
             // filter out bodies that are not in view
@@ -1540,6 +1542,16 @@ var Mouse = require('../core/Mouse');
     * Fired before rendering
     *
     * @event beforeRender
+    * @param {} event An event object
+    * @param {number} event.timestamp The engine.timing.timestamp of the event
+    * @param {} event.source The source object of the event
+    * @param {} event.name The name of the event
+    */
+
+    /**
+    * Fired at the beginning of rendering after canvas is cleared
+    *
+    * @event beginRender
     * @param {} event An event object
     * @param {number} event.timestamp The engine.timing.timestamp of the event
     * @param {} event.source The source object of the event


### PR DESCRIPTION
I needed to render a background image directly onto the canvas so that I could capture gameplay video including backgrounds using HTMLCanvasElement.captureStream() in my physics based game: https://joegaffey.itch.io/bugvsboxes

I would like to add background animations later that would also benefit from this event.
As a fairly simple game I chose not to include another canvas renderer - matter.js is the only dependency. 

Tests indicate no performance impact. 