### PR TITLE
Added lockRotation for sprite rendering

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -82,7 +82,8 @@ var Axes = require('../geometry/Axes');
                     xScale: 1,
                     yScale: 1,
                     xOffset: 0,
-                    yOffset: 0
+                    yOffset: 0,
+                    lockRotation: false
                 }
             },
             events: null,

--- a/src/render/Render.js
+++ b/src/render/Render.js
@@ -742,7 +742,9 @@ var Mouse = require('../core/Mouse');
                         texture = _getTexture(render, sprite.texture);
 
                     c.translate(part.position.x, part.position.y);
-                    c.rotate(part.angle);
+                    // rotate sprite if not lockRotation
+                    if(!part.render.sprite.lockRotation)
+                        c.rotate(part.angle);
 
                     c.drawImage(
                         texture,
@@ -753,7 +755,10 @@ var Mouse = require('../core/Mouse');
                     );
 
                     // revert translation, hopefully faster than save / restore
-                    c.rotate(-part.angle);
+
+                    // rotate sprite if not lockRotation
+                    if(!part.render.sprite.lockRotation)
+                        c.rotate(-part.angle);
                     c.translate(-part.position.x, -part.position.y);
                 } else {
                     // part polygon


### PR DESCRIPTION
This simple yet intuitive addition enables you to toggle whether or not to rotate the sprite along with the rigidbody.

I was working on a simulation where I have different sprite sheets for different angular positions for a body but due to this not being an option I had to hack my way my directly drawing in the canvas on 'afterRender' event on top of the existing rigidbody drawing. This will atleast take care of offseting that external operation.

In the future I also plan to add a function for rendering a series of sprites on given intervals based on a map of angular position--something which I have been doing through events.