### PR TITLE
fix: apply same delta from position to previous position when setParts runs

### DIFF
--- a/src/body/Body.js
+++ b/src/body/Body.js
@@ -418,13 +418,14 @@ var Axes = require('../geometry/Axes');
 
         // sum the properties of all compound parts of the parent body
         var total = Body._totalProperties(body);
+        var positionDelta = Vector.sub(body.positionPrev, body.position);
 
         body.area = total.area;
         body.parent = body;
         body.position.x = total.centre.x;
         body.position.y = total.centre.y;
-        body.positionPrev.x = total.centre.x;
-        body.positionPrev.y = total.centre.y;
+        body.positionPrev.x = total.centre.x + positionDelta.x;
+        body.positionPrev.y = total.centre.y + positionDelta.y;
 
         Body.setMass(body, total.mass);
         Body.setInertia(body, total.inertia);


### PR DESCRIPTION
## Problem
Currently when setParts is run, it sets the position and positionPrev to the new total parts centre values.  This is fine when the body is stable/constant when being set, however for actively moving objects this will cause the new body to have no delta between positions. 

This factors in when calculating the new velocity during update: https://github.com/tylerfurtwangler/matter-js/blob/master/src/body/Body.js#L638 

## Fix
This change uses the existing body `positionPrev` and `position` values to come up with a delta to apply to the body to keep the previous relative positions the same during a setParts call.

## Testing Notes
I am unfamiliar with the process, and can close this PR if more is required for the main repo. This can be seen by calling setParts on a falling object, the object "stalls" midair as it no longer has a positionPrev delta from position.