### PR TITLE
Matter.Bodies.fromVertices fix: no longer returns 'undefined'

### DIFF
--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -303,6 +303,21 @@ var Vector = require('../geometry/Vector');
             }
         }
 
+
+        if(parts.length==0)
+        {
+            for (v = 0; v < vertexSets.length; v += 1) {
+                vertices = vertexSets[v];
+              
+                vertices = Vertices.hull(vertices);
+
+                parts.push({
+                    position: { x: x, y: y },
+                    vertices: vertices
+                });
+            }
+        }
+
         // create body parts
         for (i = 0; i < parts.length; i++) {
             parts[i] = Body.create(Common.extend(parts[i], options));


### PR DESCRIPTION
I was trying to create Body with the method [Matter.Bodies.fromVertices](https://brm.io/matter-js/docs/classes/Bodies.html#method_fromVertices).

I installed [poly-decomp](https://github.com/schteppe/poly-decomp.js) package to enable automatic concave vertices decomposition and supply the the method [Matter.Bodies.fromVertices](https://brm.io/matter-js/docs/classes/Bodies.html#method_fromVertices) with vertices from drawing.

![success](https://user-images.githubusercontent.com/76631942/173723380-b16028db-ec94-4132-a6b0-acaf9abc59e6.gif)

However, for certain sets of vertices, the method [Matter.Bodies.fromVertices](https://brm.io/matter-js/docs/classes/Bodies.html#method_fromVertices) would return `undefined` at line **354** of `./src/factory/Bodies.js`

>                 return parts[0];

![no_parts_error](https://user-images.githubusercontent.com/76631942/173724559-8b03aebb-3e27-4ed5-b582-dec4046cf344.gif)

This is due to

1. The `quickDecomp()` returns empty list of decomposition near line **278** of `./src/factory/Bodies.js`
>                 // use the quick decomposition algorithm (Bayazit)
>                 var decomposed = decomp.quickDecomp(concave);
2.  The decomposition only contains small parts being skipped near line **293** of `./src/factory/Bodies.js`

>                 // skip small chunks
>                 if (minimumArea > 0 && Vertices.area(chunkVertices) < minimumArea)
>                       continue;


My change checks if the `parts` array is empty. If the array is empty, fallback to convex hull and ignore the decomposition.
The final result would look like the following.

![no_parts_error_handled](https://user-images.githubusercontent.com/76631942/173725955-1444a14e-bf59-4276-af82-2a6e6732cfad.gif)





