### PR TITLE
Fix inconsistent Bodies.fromVertices behavior

### DIFF
--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -259,7 +259,7 @@ var Vector = require('../geometry/Vector');
                 }
 
                 parts.push({
-                    position: { x: x, y: y },
+                    position: Vertices.centre(vertices),
                     vertices: vertices
                 });
             } else {


### PR DESCRIPTION
When calling `Bodies.fromVertices` with an array of `vertexSets` in which some vertexSets are convex and some are concave, the convex vertices end up in wildly different places from the concave vertices.

See the following example, where in vectorized text, the three convex parts (making up the “i” and the “o”) are out of place with the rest of the (concave) parts, even though they were correctly positioned in the input data:

<img width="400" alt="Screenshot 2022-11-19 at 1 22 45 PM" src="https://user-images.githubusercontent.com/10377391/202865865-37f016bb-5577-40a8-aa12-ac2e9c9dfdd2.png">

This occurs because the Bodies.fromVertices implementation sets the `x`, `y` of *convex* parts to the input `x`, `y` (which is the same for every part) but it sets the `x`, `y` of *concave* parts to the center of mass of the part.

This pull request makes the behavior consistent by ensuring every part has its position set to its center of mass, so that multiple vertexSets passed to `Matter.fromVertices` have their relative positions preserved. 