### PR TITLE
Fix issue with 'Bodies.circle' usage.

### DIFF
--- a/src/factory/Bodies.js
+++ b/src/factory/Bodies.js
@@ -116,6 +116,9 @@ var Vector = require('../geometry/Vector');
      * @return {body} A new circle body
      */
     Bodies.circle = function(x, y, radius, options, maxSides) {
+        if( radius === 0 )
+            throw new Error('The radius of `Bodies.circle` must be non-zero.');
+
         options = options || {};
 
         var circle = {


### PR DESCRIPTION
https://github.com/liabru/matter-js/issues/1242

## Bug reproduction path:
The issue arises when creating two circles with a `radius` of `0` passed into `Bodies.circle()`.

In this scenario, the `body.mass` becomes `0`, leading to a `NaN` in the logic within `Body.js` as shown below:
```js
// update velocity with Verlet integration
body.velocity.x = (velocityPrevX * frictionAir) + (body.force.x / body.mass) * deltaTimeSquared;
body.velocity.y = (velocityPrevY * frictionAir) + (body.force.y / body.mass) * deltaTimeSquared;
```
The occurrence of `NaN` in the above code subsequently triggers a `vertexA is undefined` error in `Collision._findSupports()`.


## Fix:
To resolve this issue, throw an explicit `Error` message when a `radius` of `0` is provided as input in `Bodies.circle()`.
- "The radius of `Bodies.circle` must be non-zero."

## Trade-offs:
### Performance:
- Introduce a `constant-time` condition check in `Bodies.circle()`.
  - Does not significantly impact performance for bulk generation calls.
  - This appears to be a minimal modification since it does not handle exceptions in engine operations.
 
## Alternative:
### Annotate only:
  - Note that providing a `radius` of `0` as input may lead to a bug.
    - "Avoid using a `radius` of `0` in dynamic logic; opt for uncalled logic instead."
  - User issue management is required since it is unclear where the issue may occur.